### PR TITLE
Enable permissions for serial connections & firmware uploading

### DIFF
--- a/org.mavlink.qgroundcontrol.yml
+++ b/org.mavlink.qgroundcontrol.yml
@@ -10,11 +10,13 @@ finish-args:
 - --socket=fallback-x11
 - --socket=pulseaudio
 - --device=dri
+- --device=all  # allow access USB Serial
 - --share=ipc
 - --share=network
 - --filesystem=home
 - --filesystem=xdg-run/gvfs # GVfs
 - --filesystem=/media # automount via udisks
+- --filesystem=/run/udev:ro # enables firmware upload & auto connecting
 
 modules:
   - name: QGroundControl


### PR DESCRIPTION
This will let QGC connect to USB Serial devices such as telemetries etc. Will also enable support for firmware uploading.

Refer to: https://github.com/flipperdevices/qFlipper/issues/95