### PR TITLE
remove redundant device arg

### DIFF
--- a/org.mavlink.qgroundcontrol.yml
+++ b/org.mavlink.qgroundcontrol.yml
@@ -9,7 +9,6 @@ finish-args:
 - --socket=wayland
 - --socket=fallback-x11
 - --socket=pulseaudio
-- --device=dri
 - --device=all  # allow access USB Serial
 - --share=ipc
 - --share=network


### PR DESCRIPTION
Addresses https://github.com/flathub/org.mavlink.qgroundcontrol/pull/6#issuecomment-1752108105