### PR TITLE
disable x-checker-data

### DIFF
--- a/org.mavlink.qgroundcontrol.yml
+++ b/org.mavlink.qgroundcontrol.yml
@@ -23,10 +23,10 @@ modules:
       - type: git
         url: https://github.com/mavlink/qgroundcontrol.git
         tag: v4.4.4
-        x-checker-data:
-          type: git
-          tag-pattern: ^v([\d.]+)$
-        commit: b809674075f9c12ee4830a5ca824308d249b7ae4
+        # x-checker-data:
+        #   type: git
+        #   tag-pattern: ^v([\d.]+)$
+        # commit: b809674075f9c12ee4830a5ca824308d249b7ae4
     buildsystem: cmake-ninja
     builddir: true
     config-opts:


### PR DESCRIPTION
Disable the External Data Checker to avoid automatic PR creation for newer QGroundControl versions, which always fail due to downloaded dependencies.